### PR TITLE
Feature/requests compat

### DIFF
--- a/fedora/client/proxyclient.py
+++ b/fedora/client/proxyclient.py
@@ -397,8 +397,13 @@ class ProxyClient(object):
                     ' json module while processing %(url)s: %(err)s') %
                     {'url': to_bytes(url), 'err': to_bytes(e)})
         except AttributeError, e:
-            # We must be on an *old* version of python-requests
-            data = json.loads(response.text)
+            # We must be on an *old* version of python-requests.
+            # This interface changed a lot early on.  It can be done away with
+            # after with get python-requests-0.12 or later in el6.
+            if response.text:
+                data = json.loads(response.text)
+            else:
+                data = json.loads(response.raw.read())
 
         if 'exc' in data:
             name = data.pop('exc')


### PR DESCRIPTION
I ran into problem when I tried it out on el6 against python-requests-0.11.1.

Two distinct issues.  One with JSON, another with the CookieJar.

Just to note, I've tested these commits with the authn features and with sequences in the params (using an older version of requests installed from PyPI).
