### PR TITLE
Feature/fix client side cookie gen

### DIFF
--- a/fedora/client/proxyclient.py
+++ b/fedora/client/proxyclient.py
@@ -40,17 +40,11 @@ except ImportError:
     from urllib.parse import urlparse
 
 try:
-    import simplejson as json
-except ImportError:
-    import json as json
-
-try:
     from hashlib import sha1 as sha_constructor
 except ImportError:
     from sha import new as sha_constructor
 
 from bunch import bunchify
-from kitchen.iterutils import isiterable
 from kitchen.text.converters import to_bytes
 
 from fedora import __version__, b_


### PR DESCRIPTION
We've been having trouble with python-request's handling of a client-side generated cookie that has domain set to "localhost".  This issue did not occur with our pycurl code.  Inspection of the previous code showed that we did not set the domain (or any cookie attributes) on the client-generated cookie that we were returning to the server.  This commit removes the setting of attributes on the client-generated cookie in our new code.

This seems to be correct because attributes on cookies (path, domain, secure, httponly, etc) are only set on a Set-Cookie header that is sent by the server to the client.  The client uses those attributes when it determines whether a particular cookie should be sent back to the server when a new url is requested but it does not include them when it passes the cookie name and values back in a Cookie header.

Wikipedia section with that in plain English: http://en.wikipedia.org/wiki/HTTP_cookie#Cookie_attributes

Relevant section from the Cookie RFC: http://tools.ietf.org/html/rfc6265#section-5.4 The fourth step in creating the cookie header is to "Output the cookie's name, the %x3D ("=") character, and the cookie's value."  The cookie's attributes were only used to determine if the data would be set; it isn't set in the Cookie header.  Also contrast with http://tools.ietf.org/html/rfc6265#section-5.2 which talks about the Set-Cookie header that is sent by the server.
