### PR TITLE
Feature/timeout fix

### DIFF
--- a/fedora/client/baseclient.py
+++ b/fedora/client/baseclient.py
@@ -76,7 +76,7 @@ class BaseClient(ProxyClient):
             the server, retry this many times.  Setting this to a negative
             number makes it try forever.  Defaults to zero, no retries.
         :kwarg timeout: A float describing the timeout of the connection. The
-            timeout only effects the connection process itself, not the
+            timeout only affects the connection process itself, not the
             downloading of the response body. Defaults to 30 seconds.
 
         .. versionchanged:: 0.3.33
@@ -293,7 +293,7 @@ class BaseClient(ProxyClient):
             value set on the instance or in :meth:`__init__` (which defaults
             to zero, no retries).
         :kwarg timeout: A float describing the timeout of the connection. The
-            timeout only effects the connection process itself, not the
+            timeout only affects the connection process itself, not the
             downloading of the response body. Defaults to 30 seconds.
         :rtype: Bunch
         :returns: The data from the server

--- a/fedora/client/proxyclient.py
+++ b/fedora/client/proxyclient.py
@@ -111,7 +111,7 @@ class ProxyClient(object):
 
     .. attribute:: timeout
         A float describing the timeout of the connection. The timeout only
-        effects the connection process itself, not the downloading of the
+        affects the connection process itself, not the downloading of the
         response body. Defaults to 30 seconds.
 
     .. versionchanged:: 0.3.33
@@ -143,7 +143,7 @@ class ProxyClient(object):
             the server, retry this many times.  Setting this to a negative
             number makes it try forever.  Defaults to zero, no retries.
         :kwarg timeout: A float describing the timeout of the connection. The
-            timeout only effects the connection process itself, not the downloading
+            timeout only affects the connection process itself, not the downloading
             of the response body. Defaults to 30 seconds.
 
         .. versionchanged:: 0.3.33
@@ -255,7 +255,7 @@ class ProxyClient(object):
             number makes it try forever.  Default to use the :attr:`retries`
             value set on the instance or in :meth:`__init__`.
         :kwarg timeout: A float describing the timeout of the connection. The
-            timeout only effects the connection process itself, not the
+            timeout only affects the connection process itself, not the
             downloading of the response body. Defaults to the :attr:`timeout`
             value set on the instance or in :meth:`__init__`.
         :returns: If ProxyClient is created with session_as_cookie=True (the


### PR DESCRIPTION
Timeout was still slightly lacking.  The timeout parameter in BaseClient.send_request() (and subclasses) was being ignored.  This patch forwards that parameter on to ProxyClient.
