### PR TITLE
Raise an appropriate error if requests times out enough times.

### DIFF
--- a/fedora/client/proxyclient.py
+++ b/fedora/client/proxyclient.py
@@ -389,6 +389,9 @@ class ProxyClient(object):
                     time.sleep(0.5)
                     continue
 
+                # Fail and raise the timeout error in its original context
+                raise
+
             # When the python-requests module gets a response, it attempts to
             # guess the encoding using "charade", a fork of "chardet" which it
             # bundles (and which we are in the process of unbundling:


### PR DESCRIPTION
Currently, if the request times out `num_retries` times in a row, then the code will fail on the `response.encoding = 'utf-8'` line which then raises an error that doesn't really tell you what happened.  It looks something like this:

``` python
Traceback (most recent call last):
  File "/usr/bin/bodhi", line 523, in <module>
    main()
  File "/usr/bin/bodhi", line 274, in main
    data = bodhi.push()
  File "/usr/lib/python2.6/site-packages/fedora/client/bodhi.py", line 244, in push
    return self.send_request('admin/push', auth=True)
  File "/usr/lib/python2.6/site-packages/fedora/client/baseclient.py", line 355, in send_request
    auth_params=auth_params, retries=retries, timeout=timeout)
  File "/usr/lib/python2.6/site-packages/fedora/client/proxyclient.py", line 403, in send_request
    response.encoding = 'utf-8'
UnboundLocalError: local variable 'response' referenced before assignment
```

By re-raising the `requests.Timeout` error, it should make things a little more obvious.
