### PR TITLE
Raise the timeout value to 120s

### DIFF
--- a/fedora/client/baseclient.py
+++ b/fedora/client/baseclient.py
@@ -77,7 +77,7 @@ class BaseClient(ProxyClient):
             number makes it try forever.  Defaults to zero, no retries.
         :kwarg timeout: A float describing the timeout of the connection. The
             timeout only affects the connection process itself, not the
-            downloading of the response body. Defaults to 30 seconds.
+            downloading of the response body. Defaults to 120 seconds.
 
         .. versionchanged:: 0.3.33
             Added the timeout kwarg
@@ -294,7 +294,10 @@ class BaseClient(ProxyClient):
             to zero, no retries).
         :kwarg timeout: A float describing the timeout of the connection. The
             timeout only affects the connection process itself, not the
-            downloading of the response body. Defaults to 30 seconds.
+            downloading of the response body. Default to use the
+            :attr:`timeout` value set on the instance or in :meth:`__init__`
+            (which defaults to 120s).
+
         :rtype: Bunch
         :returns: The data from the server
 

--- a/fedora/client/proxyclient.py
+++ b/fedora/client/proxyclient.py
@@ -112,7 +112,7 @@ class ProxyClient(object):
     .. attribute:: timeout
         A float describing the timeout of the connection. The timeout only
         affects the connection process itself, not the downloading of the
-        response body. Defaults to 30 seconds.
+        response body. Defaults to 120 seconds.
 
     .. versionchanged:: 0.3.33
         Added the timeout attribute
@@ -120,8 +120,8 @@ class ProxyClient(object):
     log = log
 
     def __init__(self, base_url, useragent=None, session_name='tg-visit',
-            session_as_cookie=True, debug=False, insecure=False, retries=0,
-            timeout=30.0):
+            session_as_cookie=True, debug=False, insecure=False, retries=None,
+            timeout=None):
         '''Create a client configured for a particular service.
 
         :arg base_url: Base of every URL used to contact the server
@@ -144,7 +144,7 @@ class ProxyClient(object):
             number makes it try forever.  Defaults to zero, no retries.
         :kwarg timeout: A float describing the timeout of the connection. The
             timeout only affects the connection process itself, not the downloading
-            of the response body. Defaults to 30 seconds.
+            of the response body. Defaults to 120 seconds.
 
         .. versionchanged:: 0.3.33
             Added the timeout kwarg
@@ -178,8 +178,17 @@ class ProxyClient(object):
                 ' constructor with session_as_cookie=False'),
                 DeprecationWarning, stacklevel=2)
         self.insecure = insecure
-        self.retries = retries or 0
-        self.timeout = timeout or 30.0
+
+        # Have to do retries and timeout default values this way as BaseClient
+        # sends None for these values if not overridden by the user.
+        if retries is None:
+            retries = 0
+        else:
+            self.retries = retries
+        if timeout is None:
+            self.timeout = 120.0
+        else:
+            self.timeout = timeout
         self.log.debug(b_('proxyclient.__init__:exited'))
 
     def __get_debug(self):


### PR DESCRIPTION
Raise the default timeout value for ProxyClient requests from 30s to 120s.  We've encountered some http queries that take longer than 30s (I've seen 50s) so setting this to 120 gives us a better margin.

Note that pycurl had a default timeout of 300s  so we could go up to that limit if this still throws many errors.
