### PR TITLE
Fix the imports of the openid extensions

### DIFF
--- a/flask_fas_openid.py
+++ b/flask_fas_openid.py
@@ -39,10 +39,10 @@ import openid
 from openid.consumer import consumer
 from openid.fetchers import setDefaultFetcher, Urllib2Fetcher
 from openid.extensions import pape, sreg
+from openid_cla import cla
+from openid_teams import teams
 
 from fedora import __version__
-import openid_cla.cla
-import openid_teams.teams
 
 class FAS(object):
 


### PR DESCRIPTION
When the extensions moved to their own package, the import location was updated in flask_fas_openid but they didn't import to the same local name .  This change fixes that.
