### PR TITLE
Hotfix/stop login i18n overwriting app i18n

### DIFF
--- a/fedora/tg/controllers.py
+++ b/fedora/tg/controllers.py
@@ -30,11 +30,11 @@ from fedora.tg.utils import request_format
 
 from turbogears.i18n.utils import get_locale 
 from turbogears.i18n.tg_gettext import tg_gettext 
- 
-def _(msg): 
+
+def f_(msg):
     ''' 
     Translate given message from current tg locale 
- 
+
     Parameters 
     :message: text to be translated 
     Returns: Translated message string 

--- a/fedora/tg/templates/genshi/login.html
+++ b/fedora/tg/templates/genshi/login.html
@@ -5,32 +5,32 @@
   py:strip="True">
 
 <?python
-  from fedora.tg.controllers import _
+  from fedora.tg.controllers import f_
 ?>
 
 <py:match path="loginform" once="true">
   <div class="panel">
     <div id="login-box" class="login">
-      <h3>${_('Log In')}</h3>
+      <h3>${f_('Log In')}</h3>
       <p py:content="unicode(select('*|text()'))" />
       <form py:if="not tg.identity.only_token"
         action="${tg.url(previous_url)}" method="post">
-        <div class="field"><label for="user_name">${_('User Name:')}</label>
+        <div class="field"><label for="user_name">${f_('User Name:')}</label>
           <input type="text" id="user_name" name="user_name" />
         </div>
-        <div class="field"><label for="password">${_('Password:')}</label>
+        <div class="field"><label for="password">${f_('Password:')}</label>
           <input type="password" id="password" name="password" />
         </div>
         <div class="field">
           <input type="submit" name="login" class="button"
-            value="${_('Login')}" />
+            value="${f_('Login')}" />
           <hiddenvals />
         </div>
       </form>
       <form py:if="tg.identity.only_token"
         action="${tg.url(previous_url)}" method="post">
-        <p><a href="http://en.wikipedia.org/wiki/CSRF">${_('CSRF attacks')}</a>
-        ${_(''' are a means for a malicious website to make a request of another
+        <p><a href="http://en.wikipedia.org/wiki/CSRF">${f_('CSRF attacks')}</a>
+        ${f_(''' are a means for a malicious website to make a request of another
         web server as the user who contacted the malicious web site.  The
         purpose of this page is to help protect your account and this server
         from attacks from such malicious web sites.  By clicking below, you are
@@ -38,12 +38,12 @@
         forwarding your authentication cookies on behalf of a malicious
         website.''')}</p>
         <input type="submit" name="csrf_login" class="button"
-          value="${_('I am a human')}" />
+          value="${f_('I am a human')}" />
         <hiddenvals />
       </form>
       <ul>
-        <li><a href="${tg.url(tg.config('fas.url', 'https://admin.fedoraproject.org/accounts').rstrip('/') + '/user/resetpass')}">${_('Forgot Password?')}</a></li>
-        <li><a href="${tg.url(tg.config('fas.url', 'https://admin.fedoraproject.org/accounts').rstrip('/') + '/user/new')}">${_('Sign Up')}</a></li>
+        <li><a href="${tg.url(tg.config('fas.url', 'https://admin.fedoraproject.org/accounts').rstrip('/') + '/user/resetpass')}">${f_('Forgot Password?')}</a></li>
+        <li><a href="${tg.url(tg.config('fas.url', 'https://admin.fedoraproject.org/accounts').rstrip('/') + '/user/new')}">${f_('Sign Up')}</a></li>
       </ul>
     </div>
   </div>
@@ -61,7 +61,7 @@
 
 <py:match path="logintoolitem" once="true">
   <li py:if="not tg.identity.anonymous" class="toolitem">
-    ${_('Welcome')}
+    ${f_('Welcome')}
     <div py:choose="unicode(select('@href'))" py:strip="True">
       <span py:when="''" py:choose="" py:strip="True">
         <span py:when="hasattr(tg.identity.user, 'display_name')"
@@ -83,22 +83,22 @@
   </li>
   <li py:if="tg.identity.anonymous and not tg.identity.only_token"
     id="login-toolitem" class="toolitem">
-    ${_('You are not logged in')}
+    ${f_('You are not logged in')}
     <form action="${tg.url('/login')}" method="POST">
-      <input type="submit" value="${_('Login')}" class="button" />
+      <input type="submit" value="${f_('Login')}" class="button" />
     </form>
   </li>
   <li py:if="tg.identity.anonymous and tg.identity.only_token"
     id="login-toolitem" class="toolitem">
-    ${_('CSRF protected')}
+    ${f_('CSRF protected')}
     <form action="${tg.url(tg.request.path_info)}" method="POST">
-      <input type="submit" name="csrf_login" value="${_('Verify Login')}" class="button" />
+      <input type="submit" name="csrf_login" value="${f_('Verify Login')}" class="button" />
     </form>
   </li>
   <li py:if="not tg.identity.anonymous or tg.identity.only_token"
     id="login-toolitem" class="toolitem">
     <form action="${tg.url('/logout')}" method="POST">
-      <input type="submit" value="${_('Logout')}" class="button" />
+      <input type="submit" value="${f_('Logout')}" class="button" />
     </form>
   </li>
 </py:match>


### PR DESCRIPTION
This fixes a problem introduced with https://github.com/fedora-infra/python-fedora/commit/5fc7c552170e55011a6bb0a5f23fe580463e1e64  (Making translations of templates in python-fedora show up in web apps).

Broken page can be seen at:

https://admin.fedoraproject.org/accounts/  if you simply set the locale (in the sidebar) to es.  Some of the text on the page is not translated into Spanish.

Page with this fix applied is at: https://admin.fedoraproject.org/accounts/ Setting the locale to es should result in a page that has many more Spanish translations.
