### PR TITLE
Defining rpm macros can't have whitespace there.

### DIFF
--- a/python-fedora.spec
+++ b/python-fedora.spec
@@ -1,6 +1,6 @@
 %if 0%{?rhel} && 0%{?rhel} <= 6
-%{!? __python2: %global __python2 /usr/bin/python2}
-%{!? python2_sitelib: %global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
+%{!?__python2:        %global __python2 /usr/bin/python2}
+%{!?python2_sitelib:  %global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 %endif
 #%%global prerel c2
 


### PR DESCRIPTION
Bugfix to the macros in the rpm spec file.
