### PR TITLE
Add forgotten requirement in setup.py for python-openid-cla

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setup(
     extras_require = {
         'tg' : ['TurboGears >= 1.0.4', 'SQLAlchemy', 'decorator'],
         'wsgi': ['repoze.who', 'Beaker', 'Paste'],
-        'flask': ['Flask', 'Flask_WTF', 'python-openid', 'python-openid-teams'],
+        'flask': ['Flask', 'Flask_WTF', 'python-openid', 'python-openid-teams',
+                    'python-openid-cla'],
         },
     entry_points = {
         'turbogears.identity.provider' : (


### PR DESCRIPTION
We need python-openid-cla for CLA stuff.
