### PR TITLE
fedoauth login tweaks

### DIFF
--- a/fedora/client/openidproxyclient.py
+++ b/fedora/client/openidproxyclient.py
@@ -38,12 +38,10 @@ import warnings
 
 try:
     # Python2
-    from urlparse import urljoin
-    from urlparse import urlparse
+    from urlparse import urljoin, urlparse, parse_qs
 except ImportError:
     # Python3 support
-    from urllib.parse import urljoin
-    from urllib.parse import urlparse
+    from urllib.parse import urljoin, urlparse, parse_qs
 
 # Hack, hack, hack around
 # the horror that is logging!
@@ -64,7 +62,6 @@ import requests
 from kitchen.text.converters import to_bytes
 # For handling an exception that's coming from requests:
 import urllib3
-import urlparse
 
 from fedora import __version__
 from fedora.client import AuthError, ServerError, LoginRequiredError, FedoraServiceError
@@ -125,7 +122,7 @@ def openid_login(session, login_url, username, password, otp=None,
         data = {}
         for r in response.history:
             if motif.match(r.url):
-                parsed = urlparse.parse_qs(urlparse.urlparse(r.url).query)
+                parsed = parse_qs(urlparse(r.url).query)
                 for key, value in parsed.items():
                     data[key] = value[0]
                 break


### PR DESCRIPTION
This branch gets the login() method working against bodhi2 + pyramid_fas_openid and the pkgdb2 + flask-fas-openid.

It really doesn't feel like the Right Way:tm: to do things, but it's the only way I could successfully authenticate through both pyramid & flask fas openid modules. Changes may need to be made to these modules or in fedoauth as opposed to these hacks in python-fedora, I'm not quite sure.
