### PR TITLE
Make avatar_url use openid ident for libravatar.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,9 +2,17 @@
 NEWS
 ====
 
-:Authors: Toshio Kuratomi, Luke Macken, Ricky Elrod, Patrick Uiterwijk
+:Authors: Toshio Kuratomi, Luke Macken, Ricky Elrod, Patrick Uiterwijk, Ralph Bean
 :Date: 19 December 2013
 :Version: 0.3.x
+
+
+------
+0.3.34 (unreleased)
+------
+
+* Updated libravatar lookups to use the user's openid identifier instead of
+  their email address.
 
 ------
 0.3.33


### PR DESCRIPTION
This change makes it so libravatar queries use the user's FAS openid identifier
instead of their email address.  Down the road, this will make integration with
libravatar, specifically in the case where we want to prompt users to change
their avatar.

The problem:  If we redirect users simply to libravatar.org, they can log in
there with an email address that we are not using or tracking.  They login,
update their photos, but then are confused as to why their photo is not
"syncing" back to Fedora Infrastructure websites.

To resolve this (if we use their openid for lookups everywhere), we can
redirect them to a specific form at libravatar.org that _already has their FAS
openid identifier filled in_.  This makes login there quick and simple, and it
resolves any mismatch between their libravatar login identifier and the
identifier we use everywhere to find their avatar.

Tested locally.
