### PR TITLE
Fix OpenID regex

### DIFF
--- a/fedora/client/openidproxyclient.py
+++ b/fedora/client/openidproxyclient.py
@@ -71,7 +71,7 @@ log.addHandler(NullHandler())
 OPENID_SESSION_NAME = 'FAS_OPENID'
 
 FEDORA_OPENID_API = 'https://id.fedoraproject.org/api/v1/'
-FEDORA_OPENID_RE = re.compile(r'^http(s)?:\/\/(|stg.|dev.)?id\.fedoraproject\.org(/)?')
+FEDORA_OPENID_RE = re.compile(r'^http(s)?:\/\/id\.(|stg.|dev.)?fedoraproject\.org(/)?')
 
 
 def _parse_service_form(response):


### PR DESCRIPTION
Staging is deployed at:
    https://id.stg.fedoraproject.org/

Not at:
    https://stg.id.fedoraproject.org/
