### PR TITLE
Use the getMessage() function as intended

### DIFF
--- a/flask_fas_openid.py
+++ b/flask_fas_openid.py
@@ -251,6 +251,7 @@ class FAS(object):
         if request_wants_json():
             output = request.getMessage(trust_root,
                                         return_to=return_to).toPostArgs()
+            output['server_url'] = request.endpoint.server_url
             return flask.jsonify(output)
         elif request.shouldSendRedirect():
             redirect_url = request.redirectURL(trust_root, return_to, False)


### PR DESCRIPTION
This is the intended way to get the message, not our hacky way of getting the internal variable.
This way, python-openid will set all the missing fields for us automagically.
Isn't that nice of it?!
