### PR TITLE
Only require CherryPy<3 on Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
 #!/usr/bin/python -tt
+import sys
 
 # Work around setuptools multi-version silliness
 try:
-    __requires__ = ['CherryPy < 3', 'Sphinx >= 1.0']
+    __requires__ = ['Sphinx >= 1.0']
+    if sys.version_info[0] == 2:
+        __requires__.append('CherryPy < 3')
     import pkg_resources
 except:
     # And also workaround the workaround being broken inside of a virtualenv


### PR DESCRIPTION
CherryPy doesn't work with Python 3, so even with [1] python-fedora is not buildable on Python 3. This patch (together with [1]) makes python-fedora buildable and importable in Python 3.

[1] https://github.com/fedora-infra/python-fedora/pull/117