### PR TITLE
Actually check the server version when tickling.

### DIFF
--- a/fedora/client/bodhi.py
+++ b/fedora/client/bodhi.py
@@ -31,6 +31,7 @@ import warnings
 import requests
 
 from six.moves import urllib
+from distutils.version import LooseVersion
 
 from fedora.client import OpenIdBaseClient, FedoraClientError, BaseClient
 import fedora.client.openidproxyclient
@@ -56,7 +57,20 @@ def BodhiClient(base_url=BASE_URL, staging=False, **kwargs):
     log.debug('Querying bodhi API version')
     api_url = base_url + 'api_version'
     response = requests.get(api_url)
-    if response.status_code == 200:
+
+    try:
+        data = response.json
+        if callable(data):
+            data = data()
+        server_version = LooseVersion(data['version'])
+    except Exception as e:
+        if 'json' in str(type(e)).lower():
+            # Claim that bodhi1 is on the server
+            server_version = LooseVersion('0.9')
+        else:
+            raise
+
+    if server_version >= LooseVersion('2.0'):
         log.debug('Bodhi2 detected')
         base_url = 'https://{}/'.format(urllib.parse.urlparse(response.url).netloc)
         return Bodhi2Client(base_url=base_url, staging=staging, **kwargs)


### PR DESCRIPTION
This is more explicit and will be sure to get around some of the
redirects we've been putting in place.