### PR TITLE
Raise exceptions from Bodhi2Client on failure.

### DIFF
--- a/fedora/client/bodhi.py
+++ b/fedora/client/bodhi.py
@@ -104,8 +104,6 @@ def errorhandled(method):
         except Exception:
             pass
         raise BodhiClientException(problems)
-
-        return result
     return wrapper
 
 


### PR DESCRIPTION
We use cornice on the server side to frame all of our APIs there, and so
error codes/messages get returned in a very nice and consistent way
(bodhi1 would just throw up on you).  This PR leverages that symmetry on
the server to produce consistent exceptions from the client.

This is related to fedora-infra/bodhi#185