### PR TITLE
Fixing syntax error with attempt to format log message instead of string

### DIFF
--- a/fedora/client/openidbaseclient.py
+++ b/fedora/client/openidbaseclient.py
@@ -176,8 +176,8 @@ class OpenIdBaseClient(OpenIdProxyClient):
             try:
                 os.makedirs(b_SESSION_DIR, mode=0o755)
             except OSError as err:
-                log.warning('Unable to create {file}: {error}').format(
-                    file=b_SESSION_DIR, error=err)
+                log.warning('Unable to create {file}: {error}'.format(
+                    file=b_SESSION_DIR, error=err))
                 return None
 
         if not os.path.exists(b_SESSION_FILE):


### PR DESCRIPTION
This is a syntax error that was showing up on an instance I have which doesn't seem to be able to create the directories it needs. Figured a pull request would be quicker than filing a ticket