### PR TITLE
improve Bodhi2Client.query compat for old client

### DIFF
--- a/fedora/client/bodhi.py
+++ b/fedora/client/bodhi.py
@@ -33,6 +33,7 @@ import logging
 import textwrap
 import warnings
 import requests
+import re
 
 from distutils.version import LooseVersion
 
@@ -240,14 +241,29 @@ class Bodhi2Client(OpenIdBaseClient):
         if 'limit' in kwargs:
             kwargs['rows_per_page'] = kwargs['limit']
             del(kwargs['limit'])
-        if 'mine' in kwargs:
+        # 'mine' may be in kwargs, but set False
+        if kwargs.get('mine'):
             kwargs['user'] = self.username
         if 'package' in kwargs:
-            kwargs['packages'] = kwargs['package']
+            # for Bodhi 1, 'package' could be a package name, build, or
+            # update ID, so try and figure it out
+            if re.search(r'(\.el|\.fc)\d\d?', kwargs['package']):
+                kwargs['builds'] = kwargs['package']
+            elif re.search(r'FEDORA-(EPEL)?-\d{4,4}', kwargs['package']):
+                kwargs['updateid'] = kwargs['package']
+            else:
+                kwargs['packages'] = kwargs['package']
             del(kwargs['package'])
         if 'release' in kwargs:
             kwargs['releases'] = kwargs['release']
             del(kwargs['release'])
+        if 'type_' in kwargs:
+            kwargs['type'] = kwargs['type_']
+            del(kwargs['type_'])
+        # Old Bodhi CLI set bugs default to "", but new Bodhi API
+        # checks for 'if bugs is not None', not 'if not bugs'
+        if 'bugs' in kwargs and kwargs['bugs'] == '':
+            kwargs['bugs'] = None
         return self.send_request('updates', verb='GET', params=kwargs)
 
     @errorhandled


### PR DESCRIPTION
This basically fixes 'bodhi -D' with the 'old' CLI client (the
one we still ship). bodhi -D is typically used like this:

bodhi -D fedfind-1.6-1.el6
bodhi -D FEDORA-EPEL-2015-8157

neither of these worked. The client submits the term as
'package'; Bodhi2Client was simply converting it to 'packages'.
But 'packages' expects bare package name(s), not NEVRs or
update IDs. The old API would try the 'update' argument as an
update ID, then if that didn't work try it as a package name,
then if *that* didn't work try it as a NEVR - see:
https://github.com/fedora-infra/bodhi/blob/bodhi1-develop/bodhi/controllers.py#L358
So we try and replicate that here, only by using regexes
instead of by running three queries.

There are two other necessary fixes also. The 'type_' arg has
to be converted to 'type' here too, and we have to convert the
'bugs' argument to None if it's an empty string, because of how
the API query_updates() method works (it does 'if bugs is not
None' rather than 'if not bugs').