### PR TITLE
This actually matters.

### DIFF
--- a/fedora/client/openidbaseclient.py
+++ b/fedora/client/openidbaseclient.py
@@ -50,7 +50,7 @@ except ImportError:
 import lockfile
 import requests
 import requests.adapters
-from urllib3.util import Retry
+from requests.packages.urllib3.util import Retry
 
 from functools import wraps
 from munch import munchify


### PR DESCRIPTION
The namespacing of Retry needs to match for some internal requests
handoff to work.

See https://github.com/sigmavirus24/requests/commit/c4bd6ea1501ee24a7e45d3e888f11d2a52e41469