### PR TITLE
Some bodhi client improvements.

### DIFF
--- a/fedora/client/bodhi.py
+++ b/fedora/client/bodhi.py
@@ -69,27 +69,8 @@ def BodhiClient(base_url=BASE_URL, staging=False, **kwargs):
         log.info('Using bodhi2 STAGING environment')
         base_url = STG_BASE_URL
 
-    log.debug('Querying bodhi API version')
-    api_url = base_url + 'api_version'
-    response = requests.get(api_url)
-
-    try:
-        data = response.json()
-        server_version = LooseVersion(data['version'])
-    except Exception as e:
-        if 'json' in str(type(e)).lower() or 'json' in str(e).lower():
-            # Claim that bodhi1 is on the server
-            server_version = LooseVersion('0.9')
-        else:
-            raise
-
-    if server_version >= LooseVersion('2.0'):
-        log.debug('Bodhi2 detected')
-        base_url = 'https://{0}/'.format(urlparse(response.url).netloc)
-        return Bodhi2Client(base_url=base_url, staging=staging, **kwargs)
-    else:
-        log.debug('Bodhi1 detected')
-        return Bodhi1Client(base_url, **kwargs)
+    log.debug('Using Bodhi2Client.')
+    return Bodhi2Client(base_url=base_url, staging=staging, **kwargs)
 
 
 def errorhandled(method):

--- a/fedora/client/openidbaseclient.py
+++ b/fedora/client/openidbaseclient.py
@@ -302,7 +302,7 @@ class OpenIdBaseClient(OpenIdProxyClient):
         try:
             with self.cache_lock:
                 with open(b_SESSION_FILE, 'rb') as f:
-                    data = json.loads(f.read())
+                    data = json.loads(f.read().decode('utf-8'))
             for key, value in data[self.session_key]:
                 self._session.cookies[key] = value
         except KeyError:
@@ -311,7 +311,7 @@ class OpenIdBaseClient(OpenIdProxyClient):
             # The file doesn't exist, so create it.
             log.debug("Creating %s", b_SESSION_FILE)
             with open(b_SESSION_FILE, 'wb') as f:
-                f.write(json.dumps({}))
+                f.write(json.dumps({}).encode('utf-8'))
 
     def _save_cookies(self):
         if not self.cache_session:
@@ -320,14 +320,14 @@ class OpenIdBaseClient(OpenIdProxyClient):
         with self.cache_lock:
             try:
                 with open(b_SESSION_FILE, 'rb') as f:
-                    data = json.loads(f.read())
+                    data = json.loads(f.read().decode('utf-8'))
             except Exception:
                 log.warn("Failed to open cookie cache before saving.")
                 data = {}
 
             data[self.session_key] = self._session.cookies.items()
             with open(b_SESSION_FILE, 'wb') as f:
-                f.write(json.dumps(data))
+                f.write(json.dumps(data).encode('utf-8'))
 
 
 __all__ = ('OpenIdBaseClient', 'requires_login')


### PR DESCRIPTION
Two things:

First, remove that bodhi server detection code.

- It was a PITA.
- It made things slow.
- We don't have a Bodhi1 server anymore.
- If people still want to use the Bodhi1Client, they can.  The code is
 still there.

Second, add python3 support for openidbaseclient.

- This fixes #116.
- I tested it with the bodhi2 cli on py3.4 and it worked!