### PR TITLE
Remove setuptools workaround.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,6 @@
 #!/usr/bin/python -tt
 import sys
 
-# Work around setuptools multi-version silliness
-try:
-    __requires__ = ['Sphinx >= 1.0']
-    if sys.version_info[0] == 2:
-        __requires__.append('CherryPy < 3')
-    import pkg_resources
-except:
-    # And also workaround the workaround being broken inside of a virtualenv
-    # *sigh*  setuptools is such a broken implementation
-    # When setuptools is imported later, it will see the CherryPy requirement
-    # and barf.  So we have to delete it here.
-    del __requires__
-
 exec(compile(open("fedora/release.py").read(), "fedora/release.py", 'exec'))
 
 from setuptools import find_packages, setup


### PR DESCRIPTION
Fixes #140.

These are both no longer necessary. That version of cherrypy and that
version of sphinx are both available, by default, on all branches of
Fedora/EPEL that we support.