### PR TITLE
Check error code returned by ipsilon.

### DIFF
--- a/fedora/client/openidproxyclient.py
+++ b/fedora/client/openidproxyclient.py
@@ -139,6 +139,11 @@ def openid_login(session, login_url, username, password, otp=None,
         data['openid.mode'] = 'checkid_setup'
     response = session.post(
         FEDORA_OPENID_API, data, verify=not openid_insecure)
+
+    if not bool(response):
+        raise ServerError(FEDORA_OPENID_API, response.status_code,
+                          'Error returned from our POST to ipsilon.')
+
     output = response.json()
 
     if not output['success']:


### PR DESCRIPTION
Relates to, but doesn't solve #158.

With this in place, I currently get the following traceback.

```python
>>> import fedora.client
>>> client = fedora.client.BodhiClient()
>>> client.csrf()
<password prompt>
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/home/threebean/devel/python-fedora/fedora/client/bodhi.py", line 80, in wrapper
    result = method(*args, **kwargs)
  File "/home/threebean/devel/python-fedora/fedora/client/bodhi.py", line 306, in csrf
    self.login(self.username, self.password)
  File "/home/threebean/devel/python-fedora/fedora/client/openidbaseclient.py", line 287, in l
ogin
    openid_insecure=self.openid_insecure)
  File "/home/threebean/devel/python-fedora/fedora/client/openidproxyclient.py", line 145, in 
openid_login
    'Error returned from our POST to ipsilon.')
ServerError: ServerError(https://id.fedoraproject.org/api/v1/, 500, Error returned from our PO
ST to ipsilon.)
```