### PR TITLE
Use assertEqual() instead of assertEquals()

### DIFF
--- a/tests/test_urlutils.py
+++ b/tests/test_urlutils.py
@@ -15,39 +15,39 @@ class TestURLUtils(unittest.TestCase):
         expected = base + "?foo=yes"
         params = dict(foo="yes")
         actual = update_qs(original, params)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_simple_idempotence(self):
         original = base + "?foo=yes"
         expected = base + "?foo=yes"
         params = dict(foo="yes")
         actual = update_qs(original, params)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_simple_with_overwrite(self):
         original = base + "?foo=yes"
         expected = base + "?foo=no"
         params = dict(foo="no")
         actual = update_qs(original, params)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_simple_without_overwrite(self):
         original = base + "?foo=yes"
         expected = base + "?foo=yes&foo=no"
         params = dict(foo="no")
         actual = update_qs(original, params, overwrite=False)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_simple_without_overwrite_and_same(self):
         original = base + "?foo=yes"
         expected = base + "?foo=yes&foo=yes"
         params = dict(foo="yes")
         actual = update_qs(original, params, overwrite=False)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_simple_with_tuples(self):
         original = base
         expected = base + "?foo=yes"
         params = [('foo', 'yes')]
         actual = update_qs(original, params)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
assertEquals() is a deprecated alias for assertEqual() and may
go away in a future version of Python:
https://docs.python.org/3/library/unittest.html#deprecated-aliases

The alias exists as far back as Python 2.6:
https://hg.python.org/cpython/file/v2.6.2/Lib/unittest.py#l386
Reviewed at https://reviews.reviewboard.org/r/7788/