### PR TITLE
Do not interpolate bodhi template values

### DIFF
--- a/fedora/client/bodhi.py
+++ b/fedora/client/bodhi.py
@@ -356,17 +356,20 @@ class Bodhi2Client(OpenIdBaseClient):
 
         for section in config.sections():
             update = {
-                'builds': section, 'bugs': config.get(section, 'bugs'),
-                'close_bugs': config.getboolean(section, 'close_bugs'),
-                'type': config.get(section, 'type'),
-                'type_': config.get(section, 'type'),
-                'request': config.get(section, 'request'),
-                'severity': config.get(section, 'severity'),
-                'notes': config.get(section, 'notes'),
-                'autokarma': config.get(section, 'autokarma'),
-                'stable_karma': config.get(section, 'stable_karma'),
-                'unstable_karma': config.get(section, 'unstable_karma'),
-                'suggest': config.get(section, 'suggest'),
+                'builds': section,
+                'bugs': config.get(section, 'bugs', raw=True),
+                'close_bugs': config.getboolean(
+                    section, 'close_bugs', raw=True),
+                'type': config.get(section, 'type', raw=True),
+                'type_': config.get(section, 'type', raw=True),
+                'request': config.get(section, 'request', raw=True),
+                'severity': config.get(section, 'severity', raw=True),
+                'notes': config.get(section, 'notes', raw=True),
+                'autokarma': config.get(section, 'autokarma', raw=True),
+                'stable_karma': config.get(section, 'stable_karma', raw=True),
+                'unstable_karma': config.get(
+                    section, 'unstable_karma', raw=True),
+                'suggest': config.get(section, 'suggest', raw=True),
                 }
 
             updates.append(update)
@@ -791,17 +794,20 @@ class Bodhi1Client(BaseClient):
             for section in config.sections():
                 update = {}
                 update['builds'] = section
-                update['type_'] = config.get(section, 'type')
-                update['request'] = config.get(section, 'request')
-                update['bugs'] = config.get(section, 'bugs')
-                update['close_bugs'] = config.getboolean(section, 'close_bugs')
-                update['notes'] = config.get(section, 'notes')
-                update['autokarma'] = config.getboolean(section, 'autokarma')
-                update['stable_karma'] = config.getint(section, 'stable_karma')
-                update['unstable_karma'] = config.getint(section,
-                                                         'unstable_karma')
-                update['suggest_reboot'] = config.getboolean(section,
-                                                             'suggest_reboot')
+                update['type_'] = config.get(section, 'type', raw=True)
+                update['request'] = config.get(section, 'request', raw=True)
+                update['bugs'] = config.get(section, 'bugs', raw=True)
+                update['close_bugs'] = config.getboolean(
+                    section, 'close_bugs', raw=True)
+                update['notes'] = config.get(section, 'notes', raw=True)
+                update['autokarma'] = config.getboolean(
+                    section, 'autokarma', raw=True)
+                update['stable_karma'] = config.getint(
+                    section, 'stable_karma', raw=True)
+                update['unstable_karma'] = config.getint(
+                    section, 'unstable_karma', raw=True)
+                update['suggest_reboot'] = config.getboolean(
+                    section, 'suggest_reboot', raw=True)
                 updates.append(update)
         return updates
 


### PR DESCRIPTION
I was submitting a Fedora update with "fedpkg update", bodhi.template contained this:

```notes=Update to 2015-11-08-fe6079b60c6b, ship COPYING* as %license```

The result was a backtrace:

```
Traceback (most recent call last):
  File "/usr/bin/bodhi", line 537, in <module>
    main()
  File "/usr/bin/bodhi", line 209, in main
    updates = bodhi.parse_file(input_file=opts.input_file)
  File "/usr/lib/python2.7/site-packages/fedora/client/bodhi.py", line 362, in parse_file
    'notes': config.get(section, 'notes'),
  File "/usr/lib64/python2.7/ConfigParser.py", line 623, in get
    return self._interpolate(section, option, value, d)
  File "/usr/lib64/python2.7/ConfigParser.py", line 691, in _interpolate
    self._interpolate_some(option, L, rawval, section, vars, 1)
  File "/usr/lib64/python2.7/ConfigParser.py", line 732, in _interpolate_some
    "'%%' must be followed by '%%' or '(', found: %r" % (rest,))
ConfigParser.InterpolationSyntaxError: '%' must be followed by '%' or '(', found: '%license'
```

I don't see why values in the template should be interpolated, so I suppose this change would fix it.