### PR TITLE
Check provider endpoint

### DIFF
--- a/flask_fas_openid.py
+++ b/flask_fas_openid.py
@@ -141,6 +141,12 @@ class FAS(object):
                 return flask.redirect(cancel_url)
             return 'OpenID request was cancelled'
         elif info.status == consumer.SUCCESS:
+            if info.endpoint.server_url != \
+                    self.app.config['FAS_OPENID_ENDPOINT']:
+                log.warn('Claim received from invalid issuer: %s',
+                         info.endpoint.server_url)
+                return 'Invalid provider issued claim!'
+
             sreg_resp = sreg.SRegResponse.fromSuccessResponse(info)
             teams_resp = teams.TeamsResponse.fromSuccessResponse(info)
             cla_resp = cla.CLAResponse.fromSuccessResponse(info)


### PR DESCRIPTION
This is a more robust and secure method of making sure that
only users from a single OpenID endpoint can log in.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>