### PR TITLE
Fields expects an array and not a string

### DIFF
--- a/fedora/client/fas2.py
+++ b/fedora/client/fas2.py
@@ -589,7 +589,7 @@ class AccountSystem(BaseClient):
         For example:
 
             >>> ret_val = FASCLIENT.people_by_key(
-            ...     key='email', search='toshio*', fields='id')
+            ...     key='email', search='toshio*', fields=['id'])
             >>> ret_val.keys()
             a.badger@[...].com
             a.badger+test1@[...].com


### PR DESCRIPTION
The old example has this consequence:

    Traceback (most recent call last):
      File "get_users.py", line 17, in <module>
        people = fasclient.people_by_key(key='email', search='toshio*', fields='id')
      File "/usr/lib/python2.7/site-packages/fedora/client/fas2.py", line 670, in people_by_key
        ' filter' % {'field': to_bytes(field)})
    KeyError: 'i is not a valid field to filter