### PR TITLE
fas2: Drop the override on my email address

### DIFF
--- a/fedora/client/fas2.py
+++ b/fedora/client/fas2.py
@@ -189,8 +189,6 @@ class AccountSystem(BaseClient):
             109464: 'cassmodiah@fedoraproject.org',
             # Robert M. Albrecht: romal@gmx.de
             101475: 'mail@romal.de',
-            # Mathieu Bridon: mathieu.bridon@gmail.com
-            100753: 'bochecha@fedoraproject.org',
             # Davide Cescato: davide.cescato@iaeste.ch
             123204: 'ceski@fedoraproject.org',
             # Nick Bebout: nick@bebout.net


### PR DESCRIPTION
A while ago, I wanted to use my @fp.o alias for my RHBZ account.

I haven't been doing that for a while now, and there's apparently a hotfix on pkgdb that removes these 2 lines.

This commit removes the 2 lines, so that:

1. the hotfix is not necessary any more
2. I stop receiving emails every time there's an update and the hotfix hasn't been applied yet

(Also, wow, that gmail address has been closed for so long!)