### PR TITLE
openidbaseclient: clear cookies on login

### DIFF
--- a/fedora/client/openidbaseclient.py
+++ b/fedora/client/openidbaseclient.py
@@ -274,6 +274,12 @@ class OpenIdBaseClient(OpenIdProxyClient):
             raise AuthError("Username may not be %r at login." % username)
         if not password:
             raise AuthError("Password required for login.")
+        # It looks like we're really doing this. Let's make sure that we don't
+        # collide various cookies, and clear every cookie we had up until now
+        # for this service.
+        self._session.cookies.clear()
+        self._save_cookies()
+
         response = openid_login(
             session=self._session,
             login_url=self.login_url,


### PR DESCRIPTION
If we previously had a session that is now expired, or became invalid for
any other reason, we should make sure to clear those cookies before we
issue the login.
The problem is that Flask, when presented with an invalid session, first
sends a new, blank session, and that does not overwrite the previously
existing cookie in requests, but it does take precedence.
That means that if we later get a session with a return URL, requests
will still send the cleared cookie, breaking the login process.

Fixes: RHBZ#1317579

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>