### PR TITLE
Fix detection of update ID as query in BodhiClient

### DIFF
--- a/fedora/client/bodhi.py
+++ b/fedora/client/bodhi.py
@@ -241,7 +241,7 @@ class Bodhi2Client(OpenIdBaseClient):
             # update ID, so try and figure it out
             if re.search(r'(\.el|\.fc)\d\d?', kwargs['package']):
                 kwargs['builds'] = kwargs['package']
-            elif re.search(r'FEDORA-(EPEL)?-\d{4,4}', kwargs['package']):
+            elif re.search(r'FEDORA-(EPEL-)?\d{4,4}', kwargs['package']):
                 kwargs['updateid'] = kwargs['package']
             else:
                 kwargs['packages'] = kwargs['package']


### PR DESCRIPTION
Whoops - the regex would only match on FEDORA-EPEL-YYYY or
FEDORA--YYYY (note, two dashes). Which isn't gonna work. This
makes `bodhi -D FEDORA-2017-376ae2b92c` (for e.g.) actually
work again.