### PR TITLE
requires_login() now handles 403's correctly.

### DIFF
--- a/fedora/client/openidbaseclient.py
+++ b/fedora/client/openidbaseclient.py
@@ -80,7 +80,7 @@ def requires_login(func):
                 '<title>OpenID transaction in progress</title>' in output.text:
             raise LoginRequiredError(
                 '{0} requires a logged in user'.format(output.url))
-        elif output and output.status_code == 403:
+        elif output.status_code == 403:
             raise LoginRequiredError(
                 '{0} requires a logged in user'.format(output.url))
         return output


### PR DESCRIPTION
fixes #196

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>