### PR TITLE
Fix Python 3 incompatibility

### DIFF
--- a/fedora/client/openidbaseclient.py
+++ b/fedora/client/openidbaseclient.py
@@ -314,7 +314,7 @@ class OpenIdBaseClient(OpenIdProxyClient):
         try:
             with self.cache_lock:
                 with open(b_SESSION_FILE, 'rb') as f:
-                    data = json.loads(f.read().decode('utf-8'))
+                    data = json.loads(f.read(), encoding='utf-8')
             for key, value in data[self.session_key]:
                 self._session.cookies[key] = value
         except KeyError:
@@ -335,7 +335,7 @@ class OpenIdBaseClient(OpenIdProxyClient):
             try:
                 check_file_permissions(b_SESSION_FILE, True)
                 with open(b_SESSION_FILE, 'rb') as f:
-                    data = json.loads(f.read().decode('utf-8'))
+                    data = json.loads(f.read(), encoding='utf-8')
             except UnsafeFileError as e:
                 log.debug('Clearing sessions: {}'.format(str(e)))
                 os.unlink(b_SESSION_FILE)


### PR DESCRIPTION
`str` object has no `decode` method