### PR TITLE
Prevent people from injecting // urls

### DIFF
--- a/fedora/tg/utils.py
+++ b/fedora/tg/utils.py
@@ -81,7 +81,7 @@ def url(tgpath, tgparams=None, **kwargs):
     '''
     if not isinstance(tgpath, six.string_types):
         tgpath = '/'.join(list(tgpath))
-    if not tgpath.startswith('/'):
+    if not tgpath.startswith('/') or tgpath.startswith('//'):
         # Do not allow the url() function to be used for external urls.
         # This function is primarily used in redirect() calls, so this prevents
         # covert redirects and thus CSRF leaking.


### PR DESCRIPTION
Applications should handle this, but might not do so.
Let's just protect against possible issues.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>