### PR TITLE
The encoding arg of json.loads() is ignored and deprecated

### DIFF
--- a/fedora/client/openidbaseclient.py
+++ b/fedora/client/openidbaseclient.py
@@ -314,7 +314,7 @@ class OpenIdBaseClient(OpenIdProxyClient):
         try:
             with self.cache_lock:
                 with open(b_SESSION_FILE, 'rb') as f:
-                    data = json.loads(f.read(), encoding='utf-8')
+                    data = json.loads(f.read().decode('utf-8'))
             for key, value in data[self.session_key]:
                 self._session.cookies[key] = value
         except KeyError:


### PR DESCRIPTION
See https://docs.python.org/3/library/json.html#json.loads

This fixes the test suite on Python 3.