### PR TITLE
changed path for module 'AccountSystem' to fedora.client.fas2.AccountSystem in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ System`_ easier.
 
 General Purpose API
 ===================
-The ``fedora.accounts.fas2`` module allows code to integrate with the `Fedora
+The ``fedora.client.fas2`` module allows code to integrate with the `Fedora
 Account System`_. It uses the JSON interface provided by the Account System
 servre to retrieve information about users.
 
@@ -101,11 +101,11 @@ At the moment, there are only a few methods implemented. Full documentation on
 these methods is available from the ``AccountSystem``'s docstrings from the
 interpreter or, for instance, by running::
 
-    $ pydoc fedora.accounts.fas2.AccountSystem
+    $ pydoc fedora.client.fas2.AccountSystem
 
 Here's an example of using the ``AccountSystem``::
 
-	from fedora.accounts.fas2 import AccountSystem
+	from fedora.client.fas2 import AccountSystem
 	from fedora.client import AuthError
 
 	# Get an AccountSystem object.  All AccountSystem methods need to be

--- a/doc/client.rst
+++ b/doc/client.rst
@@ -225,7 +225,7 @@ A few things to note:
    bandwidth downloading the data to get information that more closely matches
    what you need.
 
-See ``pydoc fedora.accounts.fas2`` for a module that implements a standard
+See ``pydoc fedora.client.fas2`` for a module that implements a standard
 client API for the `Fedora Account System`_
 
 .. _`Fedora Package Database`: https://fedorahosted.org/packagedb


### PR DESCRIPTION
Changed the path for module `AccountSystem` to `fedora.client.fas2.AccountSystem` in following files:

- README.rst
- doc/client.rst