### PR TITLE
testing new class for freeipa API

### DIFF
--- a/fedora/client/__init__.py
+++ b/fedora/client/__init__.py
@@ -157,6 +157,7 @@ def check_file_permissions(filename, allow_notexists=False):
 from fedora.client.proxyclient import ProxyClient
 from fedora.client.fasproxy import FasProxyClient
 from fedora.client.baseclient import BaseClient
+from fedora.client.fasjsonclient import NewAccountSystem
 from fedora.client.openidproxyclient import OpenIdProxyClient
 from fedora.client.openidbaseclient import OpenIdBaseClient
 from fedora.client.fas2 import AccountSystem, FASError, CLAError
@@ -166,6 +167,6 @@ from fedora.client.wiki import Wiki
 __all__ = ('FedoraServiceError', 'ServerError', 'AuthError', 'AppError',
            'FedoraClientError', 'LoginRequiredError', 'DictContainer',
            'FASError', 'CLAError', 'BodhiClientException',
-           'ProxyClient', 'FasProxyClient', 'BaseClient', 'OpenIdProxyClient',
+           'ProxyClient', 'FasProxyClient', 'BaseClient', 'NewAccountSystem', 'OpenIdProxyClient',
            'OpenIdBaseClient', 'AccountSystem', 'BodhiClient',
            'Wiki')

--- a/fedora/client/fasjsonclient.py
+++ b/fedora/client/fasjsonclient.py
@@ -1,0 +1,41 @@
+from fasjson_client import Client
+
+
+class NewAccountSystem(object):
+    def __init__(self, base_url, principal=None, bravado_config=None, api_version=1):
+        self.client = Client(url=base_url, principal=principal, bravado_config=bravado_config, api_version=api_version)
+
+    def group_by_name(self, groupname):
+        '''
+        Returns a group object based on its name
+        
+        :arg groupname: The string representing the name of the group to retrieve
+        '''
+        return self.client.groups.get_group(name=groupname).response().result
+
+    def groups(self):
+        '''Returns a list of all groups'''
+        return self.client.groups.list_groups().response().result
+
+    def group_members(self, groupname):
+        '''Returns a list of members of a group given the group name
+        
+        :arg groupname: The string representing the name of the group
+        '''
+        return self.client.groups.get_group_members(name=groupname).response().result
+    
+    def person_by_username(self, username):
+        '''
+        Returns a person object based on their username
+        
+        :arg username: The username of the person to retrieve
+        '''
+        return self.client.users.get_user(username=username).response().result
+    
+    def user_data(self):
+        '''Returns a list of all users'''
+        return self.client.users.list_users().response().result
+
+    def me(self):
+        '''Returns information about the current user or service'''
+        return self.client.me.whoami().response().result

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ beautifulsoup4
 openidc-client
 urllib3
 six
+fasjson-client

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'six >= 1.4.0',
         'lockfile',
         'openidc-client',
+        'fasjson-client',
     ],
     extras_require={
         'wsgi': ['repoze.who', 'Beaker', 'Paste'],

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
     beautifulsoup4
     urllib3
     lockfile
+    fasjson-client
     -r{toxinidir}/test_requirements.txt
     py26: unittest2
     py26: ordereddict


### PR DESCRIPTION
This change adds the new fasjson-client to the library and also updates some of the methods to use it. Not all methods will be supported by fasjson so I need to add deprecated messages to those. 
This is to support the move away from FAS and towards the new FreeIPA backed AAA solution.

Adding this for early feedback on the approach. I've tested it and I have made the responses the same as apps will expect.

The API won't be broken so apps can just be updated to provide `newAPI=True` to `AccountSystem` and everything should work as before.

Thoughts?

Signed-off-by: Stephen Coady <scoady@redhat.com>