### PR TITLE
Support the new AAA system

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,18 @@ NEWS
 ====
 
 :Authors: Toshio Kuratomi, Luke Macken, Ricky Elrod, Patrick Uiterwijk, Ralph Bean
-:Version: 1.0.0
+:Version: 1.1.0
+
+------
+1.1.0
+------
+
+New features:
+
+* Support for the new AAA system, which adds users who have signed agreement
+  "foobar" to the ``signed_foobar`` group. Make use of this to set the
+  ``cla_done`` key.
+
 
 ------
 1.0.0

--- a/flask_fas_openid.py
+++ b/flask_fas_openid.py
@@ -169,6 +169,10 @@ class FAS(object):
             if teams_resp:
                 # The groups do not contain the cla_ groups
                 user['groups'] = frozenset(teams_resp.teams)
+            # In the new AAA system, signing an agreement adds the user to a
+            # specific group. The FPCA has replaced the CLA.
+            if "signed_fpca" in user["groups"]:
+                user["cla_done"] = True
             if ax_resp:
                 ssh_keys = ax_resp.get(
                     'http://fedoauth.org/openid/schema/SSH/key')


### PR DESCRIPTION
In the new AAA system, signing an agreement adds the user to a specific group. Set the `cla_done` attribute accordingly.