### PR TITLE
Fix typos

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -754,7 +754,7 @@ Incompatibilities
 =================
 * Removal of camelCase.  Rename keyword arguments and public instance variables:
   * client.BaseClient
-    *Note* that changes to this class propogate out to the same variable in
+    *Note* that changes to this class propagate out to the same variable in
     derived classes like fas2.AccountSystem and the BaseClient used in
     JsonFasIdentity.
     * __init__(): baseURL => base_url

--- a/doc/flask_fas_openid.rst
+++ b/doc/flask_fas_openid.rst
@@ -80,7 +80,7 @@ authentication::
     fas = FAS(app)
 
     # Application configuration
-    # SECRET_KEY is necessary for the Flask session system.  It nees to be secret to
+    # SECRET_KEY is necessary for the Flask session system.  It needs to be secret to
     # make the sessions secret but if you have multiple servers behind
     # a load balancer, the key needs to be the same on each.
     app.config['SECRET_KEY'] = 'change me!'


### PR DESCRIPTION
Debian's lintian caught these two typos, so I'm submitting them
upstream :-).