### PR TITLE
Compatibility with Python 3.12: use ConfigParser instead of SafeConfigParser

### DIFF
--- a/releaseutils.py
+++ b/releaseutils.py
@@ -66,7 +66,7 @@ def setup_message_compiler():
 def build_catalogs():
     # Get the directory with message catalogs
     # Reuse transifex's config file first as it will know this
-    cfg = configparser.SafeConfigParser()
+    cfg = configparser.ConfigParser()
     cfg.read('.tx/config')
     cmd, args = setup_message_compiler()
 


### PR DESCRIPTION
Several names deprecated in the configparser way back in 3.2 have been removed per gh-89336:
    - configparser no longer has a SafeConfigParser class. Use the shorter ConfigParser name instead.